### PR TITLE
MISTAKE

### DIFF
--- a/cat_play.c
+++ b/cat_play.c
@@ -113,7 +113,7 @@ void printbody()
 
 void levelcleared()
 {
-  char warp[3];
+  char warp[2];
   int value;
 
   leveldone=true;
@@ -123,7 +123,7 @@ void levelcleared()
     warp[0]='0';
   warp[1]=(char) background[altobj.y+2][altobj.x+1]-161;
   if ( (warp[1]<'0') || (warp[1]>'9') )
-    warp[2]=' ';
+    warp[1]=' ';
  value = atoi (warp);
 
   if (value>0)


### PR DESCRIPTION
Based on history (commit ba34c6a8d19817e171ff4e39d62d56e5cca08ec9), the warp array value was increased to 3 because of a Clang warning.

However, the reason why the warning was raised, was actually another bug.

If the value assigned to the second element, is not a valid number:

    if ( (warp[1]<'0') || (warp[1]>'9') )
      warp[2]=' ';

then it should be cleared; however, its index is `1`, not `2`.

The fix should have been therefore to fix the index, not the array size.